### PR TITLE
Add Solax Manual to device list

### DIFF
--- a/custom_components/mypv/select.py
+++ b/custom_components/mypv/select.py
@@ -75,6 +75,7 @@ class MpvCtrlTypeSelect(CoordinatorEntity, SelectEntity):
             109: "Carlo Gavazzi EM24 Manual",
             111: "Sungrow Manual",
             112: "Fronius Gen24 Manual",
+            119: "Solax Manual",
             200: "Huawei (Modbus RTU)",
             201: "Growatt (Modbus RTU)",
             202: "Solax (Modbus RTU)",


### PR DESCRIPTION
Add missing "Solax Manual" control type with key 119 to the MpvCtrlTypeSelect enum in select.py