### PR TITLE
Fixed: Moved voltages L2 and L3 to diagnostics on ACTHOR 9s (aligning with mains/L1 voltage)

### DIFF
--- a/custom_components/mypv/sensor.py
+++ b/custom_components/mypv/sensor.py
@@ -98,6 +98,8 @@ _DIAGNOSTIC_DISABLED_KEYS = frozenset(
         "p9s_upd_state",
         "temp_ps",
         "volt_mains",
+        "volt_L2",
+        "volt_L3"
     }
 )
 


### PR DESCRIPTION
On my ACTHOR 9s, the voltages for L2 and L3 were shown as sensors. This commit adds them to the exclude so they align with Mains/L1 voltage which is shown as diagnostics.